### PR TITLE
[EC][82042940] add unary form for ops-routes

### DIFF
--- a/src/clj_ops/core.clj
+++ b/src/clj_ops/core.clj
@@ -26,16 +26,19 @@
      - build-info :: a map containing the build information for this particular jar.
      - env :: a delay containing a map of the environment variables
      - config :: a function returning the app specific configuration (ie. Confusion)"
-  [build-info env config]
-  (context "/ops" []
-    (GET "/heartbeat" [] "OK")
-    (GET "/version" []
-      (json-response build-info))
-    (GET "/env" []
-      (html5 (seq->hiccup-table (sort-by first @env))))
-    (GET "/env.json" []
-      (json-response @env))
-    (GET "/config" []
-      (html5 (seq->hiccup-table (config))))
-    (GET "/config.json" []
-      (json-response (config)))))
+  ([{:keys [build-info env config] :as m}]
+   (ops-routes build-info env config))
+
+  ([build-info env config]
+   (context "/ops" []
+     (GET "/heartbeat" [] "OK")
+     (GET "/version" []
+       (json-response build-info))
+     (GET "/env" []
+       (html5 (seq->hiccup-table (sort-by first @env))))
+     (GET "/env.json" []
+       (json-response @env))
+     (GET "/config" []
+       (html5 (seq->hiccup-table (config))))
+     (GET "/config.json" []
+       (json-response (config))))))


### PR DESCRIPTION
Can now pass a map containing keys for build-info, env, config
